### PR TITLE
Assign meaningful names to audio streams

### DIFF
--- a/hsmodem/hsmodem.cpp
+++ b/hsmodem/hsmodem.cpp
@@ -390,14 +390,14 @@ void startModem()
     }
 
     // int TX audio and modulator
-    io_capidx = kmaudio_startCapture(captureDeviceName, caprate);
+    io_capidx = kmaudio_startCapture(captureDeviceName, caprate, "Modem RX");
     if (io_capidx == -1)
     {
         printf("CAP: cannot open device: %s\n", captureDeviceName);
         return;
     }
     
-    io_pbidx = kmaudio_startPlayback(playbackDeviceName, caprate);
+    io_pbidx = kmaudio_startPlayback(playbackDeviceName, caprate, "Modem TX");
     if (io_pbidx == -1)
     {
         printf("PB: cannot open device: %s\n", playbackDeviceName);
@@ -429,13 +429,13 @@ void initVoice()
         if (VoiceAudioMode == VOICEMODE_LISTENAUDIOIN && caprate == 44100)
             srate = 44100;
 
-        voice_capidx = kmaudio_startCapture(micDeviceName, srate);
+        voice_capidx = kmaudio_startCapture(micDeviceName, srate, "Voice Input");
         if (voice_capidx == -1)
         {
             printf("Voice CAP: cannot open device: %s\n", micDeviceName);
             return;
         }
-        voice_pbidx = kmaudio_startPlayback(lsDeviceName, srate);
+        voice_pbidx = kmaudio_startPlayback(lsDeviceName, srate, "Voice Output");
         if (voice_pbidx == -1)
         {
             printf("Voice PB: cannot open device: %s\n", lsDeviceName);

--- a/hsmodem/libkmaudio/libkmaudio.h
+++ b/hsmodem/libkmaudio/libkmaudio.h
@@ -127,14 +127,14 @@ int kmaudio_getDeviceList();
 * starts a capturing stream from devname with samprate
 * returns: id of the capture stream or -1 = error
 */
-int kmaudio_startCapture(char* devname, int samprate);
+int kmaudio_startCapture(char* devname, int samprate, char* description);
 
 /*
 * starts a playback stream to devname with samprate
 * returns: id of the playback stream or -1 = error
 */
 
-int kmaudio_startPlayback(char* devname, int samprate);
+int kmaudio_startPlayback(char* devname, int samprate, char* description);
 
 /* 
 * plays len samples from psamp to device id

--- a/hsmodem/libkmaudio/libkmaudio_capture.cpp
+++ b/hsmodem/libkmaudio/libkmaudio_capture.cpp
@@ -49,7 +49,7 @@ void close_capture_stream(int idx)
 	}
 }
 
-int kmaudio_startCapture(char* devname, int samprate)
+int kmaudio_startCapture(char* devname, int samprate, char* description)
 {
 	printf("Start request for CAP stream:%s\n", devname);
 

--- a/hsmodem/libkmaudio/libkmaudio_capture_linux.cpp
+++ b/hsmodem/libkmaudio/libkmaudio_capture_linux.cpp
@@ -121,7 +121,7 @@ void close_capture_stream(int idx)
     }
 }
 
-int kmaudio_startCapture(char* devname, int samprate)
+int kmaudio_startCapture(char* devname, int samprate, char* description)
 {
     printf("Start request for CAP stream:%s\n", devname);
 
@@ -193,6 +193,7 @@ int kmaudio_startCapture(char* devname, int samprate)
     devlist[idx].instream->read_callback = read_callback;
     devlist[idx].instream->overflow_callback = overflow_callback;
     devlist[idx].instream->userdata = &(devlist[idx].index);
+    devlist[idx].instream->name = description;
 
     int err = 0;
     if ((err = soundio_instream_open(devlist[idx].instream))) {

--- a/hsmodem/libkmaudio/libkmaudio_init_linux.cpp
+++ b/hsmodem/libkmaudio/libkmaudio_init_linux.cpp
@@ -45,6 +45,7 @@ int kmaudio_init_linux()
         printf("soundio_create: out of memory\n");
         return -1;
     }
+    soundio->app_name = "AMSAT-DL HS Modem";
 
     if ((err = soundio_connect(soundio))) {
         printf("soundio_connect: %s\n", soundio_strerror(err));

--- a/hsmodem/libkmaudio/libkmaudio_playback.cpp
+++ b/hsmodem/libkmaudio/libkmaudio_playback.cpp
@@ -51,7 +51,7 @@ void close_playback_stream(int idx)
 	}
 }
 
-int kmaudio_startPlayback(char* devname, int samprate)
+int kmaudio_startPlayback(char* devname, int samprate, char* description)
 {
 	printf("Start request for PB stream:%s\n", devname);
 

--- a/hsmodem/libkmaudio/libkmaudio_playback_linux.cpp
+++ b/hsmodem/libkmaudio/libkmaudio_playback_linux.cpp
@@ -151,7 +151,7 @@ void close_playback_stream(int idx)
     }
 }
 
-int kmaudio_startPlayback(char* devname, int samprate)
+int kmaudio_startPlayback(char* devname, int samprate, char* description)
 {
     printf("Start request for PB stream:%s\n", devname);
     
@@ -223,6 +223,7 @@ int kmaudio_startPlayback(char* devname, int samprate)
     devlist[idx].outstream->write_callback = write_callback;
     devlist[idx].outstream->underflow_callback = underflow_callback;
     devlist[idx].outstream->userdata = &(devlist[idx].index);
+    devlist[idx].outstream->name = description;
 
     int err = 0;
     if ((err = soundio_outstream_open(devlist[idx].outstream))) {

--- a/hsmodem/soundio.cpp
+++ b/hsmodem/soundio.cpp
@@ -456,6 +456,7 @@ int io_init_sound(char *pbname, char *capname)
         return 0;
     }
 #endif
+    soundio->app_name = "AMSAT-DL HS Modem";
 
     io_readAudioDevices();
     io_init_pipes();

--- a/hsmodem/voiceio.cpp
+++ b/hsmodem/voiceio.cpp
@@ -235,6 +235,7 @@ int io_init_voice(char* lsname, char* micname)
         return 0;
     }
 #endif
+    voice_soundio->app_name = "AMSAT-DL HS Modem";
 
     if (lsname == NULL || micname == NULL || strlen(lsname) < 3 || strlen(micname) < 3)  // no devices defined yet
     {


### PR DESCRIPTION
Without this change, all audio streams appear as "SoundIO: SoundIoInStream" or "SoundIO: SoundIoOutStream", which makes adjusting settings in pavucontrol hard. This changes the application label to "AMSAT-DL HS Modem" and labels the modem and voice channels separately.

Device list in pavucontrol before this change:
![soundio png 2021-04-27 220126 jaSCNV](https://user-images.githubusercontent.com/1021828/116305569-3fb16e80-a7a4-11eb-8a70-83cd3ae3af05.png)

With this change:
![soundio-names png 2021-04-27 220321 Jm8u9N](https://user-images.githubusercontent.com/1021828/116305700-6d96b300-a7a4-11eb-81df-1c7af2bbe243.png)
