### PR TITLE
Support Pulseaudio "monitor" devices

### DIFF
--- a/hsmodem/libkmaudio/libkmaudio_getDevices_Linux.cpp
+++ b/hsmodem/libkmaudio/libkmaudio_getDevices_Linux.cpp
@@ -170,7 +170,6 @@ int scan_devices()
     {
         struct SoundIoDevice* device = soundio_get_input_device(soundio, i);
         if (device == NULL) continue;
-        if (strstr(device->name, "onitor")) continue;
         if (device->probe_error) continue;
 
         didx = getDevlistIndex(device->name, device->id);
@@ -193,7 +192,6 @@ int scan_devices()
     {
         struct SoundIoDevice* device = soundio_get_output_device(soundio, i);
         if (device == NULL) continue;
-        if (strstr(device->name, "onitor")) continue;
         if (device->probe_error) continue;
 
         didx = getDevlistIndex(device->name, device->id);


### PR DESCRIPTION
In Pulseaudio, each output device has a corresponding input device.
These are actually useful, e.g. when listening to a received signal on
the headphones (perhaps from the websdr or some SDR software), it makes
sense to attach the HS modem to "Monitor of Headphones" to have it
decode it. Pulseaudio also supports virtual sinks that can be fed from
SDR software, and letting the HS modem listen on "Monitor of virtual
sink" will enable decoding.